### PR TITLE
Semantically version the intake process

### DIFF
--- a/intake-process.md
+++ b/intake-process.md
@@ -6,6 +6,8 @@
    - [S2 Intake Process Overview](#s2)
    - [S3 Core Intake Process](#s3)
    - [S4 Exit Criteria](#s4)
+- [Meta](#meta)
+   - [Versioning](#versioning)
 
 Version 1.0.0.
 
@@ -227,3 +229,14 @@ The uPortal Intake Process varies from the Apereo Incubation Process in the foll
 *   Sub-project shall be hosted with the other uPortal sub-projects, currently at GitHub.
 *   GitHub docs are used in lieu of a project website.
 
+<a name="meta"></a>
+## Meta
+
+<a name="versioning"></a>
+#### Versioning
+
+Semantically versioned.
+
+Fixes that do not change the process are patch-level changes. Changes beyond
+fixes are minor-level changes. Changes that amount to a new, incompatible
+process are major changes.

--- a/intake-process.md
+++ b/intake-process.md
@@ -8,6 +8,7 @@
    - [S4 Exit Criteria](#s4)
 - [Meta](#meta)
    - [Versioning](#versioning)
+   - [History](#history)
 
 Version 1.0.0.
 
@@ -240,3 +241,8 @@ Semantically versioned.
 Fixes that do not change the process are patch-level changes. Changes beyond
 fixes are minor-level changes. Changes that amount to a new, incompatible
 process are major changes.
+
+<a name="history"></a>
+### History
+
+1.0.0 : initial named version (~2018-05-21)

--- a/intake-process.md
+++ b/intake-process.md
@@ -7,6 +7,7 @@
    - [S3 Core Intake Process](#s3)
    - [S4 Exit Criteria](#s4)
 
+Version 1.0.0.
 
 This is an intake process for sub-projects that are intended to be part of the greater uPortal Ecosystem. 
 By virtue of being a sub-project, certain stipulations are accepted that allow this process to be easier and more


### PR DESCRIPTION
Declare the intake process `1.0.0` and start semantically versioning it and tracking its history.

Useful for clarifying what version of the doc translations to various languages were translated from.